### PR TITLE
Implement keep-alive communication when acquisition is stopped

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -18,7 +18,7 @@ DANTE=$(SUPPORT)/dante-1-0
 
 # dante requires areaDetector, and areaDetector/configure/RELEASE_PRODS.local already defines
 # ASYN, CALC, etc.
-AREA_DETECTOR=$(SUPPORT)/areaDetector-3-10
+AREA_DETECTOR=$(SUPPORT)/areaDetector-3-11
 -include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
 -include $(AREA_DETECTOR)/configure/RELEASE_PRODS.local
 

--- a/danteApp/Db/dante.template
+++ b/danteApp/Db/dante.template
@@ -200,6 +200,17 @@ record(bo,"$(P)$(R)DoReadAll") {
     field(ONAM, "Read")
 }
 
+# This record scans periodically when acquisition is not active to keep the socket connection alive
+record(bo,"$(P)$(R)KeepAlive") {
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT))DanteKeepAlive")
+    field(SCAN,"10 second")
+    field(DISV,"1")
+    field(SDIS,"$(P)$(R)MCAAcquireBusy NPP NMS")
+    field(ZNAM,"Done")
+    field(ONAM,"Poll")
+}
+
 record(bo,"$(P)$(R)ReadTrace") {
     field(DTYP, "asynInt32")
     field(OUT,"@asyn($(PORT))DanteReadTrace")

--- a/danteApp/danteSrc/dante.cpp
+++ b/danteApp/danteSrc/dante.cpp
@@ -264,6 +264,7 @@ Dante::Dante(const char *portName, const char *ipAddress, int totalBoards, size_
     createParam(DanteGatingModeString,              asynParamInt32,   &DanteGatingMode);
     createParam(DanteMappingPointsString,           asynParamInt32,   &DanteMappingPoints);
     createParam(DanteListBufferSizeString,          asynParamInt32,   &DanteListBufferSize);
+    createParam(DanteKeepAliveString,               asynParamInt32,   &DanteKeepAlive);
 
     /* Commands from MCA interface */
     createParam(mcaDataString,                     asynParamInt32Array, &mcaData);
@@ -559,6 +560,11 @@ asynStatus Dante::writeInt32( asynUser *pasynUser, epicsInt32 value)
                 }
             }
         }
+    }
+    else if (function == DanteKeepAlive) {
+        // This just periodically reads the firmware version of the first board to keep the socket alive
+        callId_ = getFirmware(danteIdentifier_, 0);
+        waitReply(callId_, danteReply_, "getFirmware");
     }
 
     /* Call the callback */

--- a/danteApp/danteSrc/dante.h
+++ b/danteApp/danteSrc/dante.h
@@ -124,7 +124,7 @@ struct mappingAdvStats {
 #define DanteGatingModeString               "DanteGatingMode"
 #define DanteMappingPointsString            "DanteMappingPoints"
 #define DanteListBufferSizeString           "DanteListBufferSize"
-
+#define DanteKeepAliveString                "DanteKeepAlive"
 
 class Dante : public asynNDArrayDriver
 {
@@ -221,6 +221,8 @@ protected:
     int DanteGatingMode;                  /* int32 */
     int DanteMappingPoints;               /* int32 */
     int DanteListBufferSize;              /* int32 */
+    int DanteKeepAlive;                   /* int32 */
+
 
     /* Commands from MCA interface */
     int mcaData;                   /* int32Array, write/read */


### PR DESCRIPTION
This fixes #26.  It adds a new KeepAlive record with SCAN=10 second".  This record is disabled if acquisition is active.  The record causes the driver writeInt32 method to call getFirmware() for the first board in the system.  This does some minimal communication which keeps the socket connection open.