### PR TITLE
Allow alternative Linux architecture naming conventions

### DIFF
--- a/danteApp/danteSrc/Makefile
+++ b/danteApp/danteSrc/Makefile
@@ -9,12 +9,14 @@ include $(TOP)/configure/CONFIG
 DBD += mcaDanteSupport.dbd
 PROD_NAME = mcaDanteApp
 
-ifeq (x86_64, $(findstring x86_64, $(ARCH_CLASS)))
+ifeq ($(OS_CLASS), Linux)
+ifeq ($(ARCH_CLASS), x86_64)
   USR_CXXFLAGS_Linux += -std=c++11
   LIBRARY_IOC_Linux += mcaDante
   PROD_IOC_Linux  += $(PROD_NAME)
   PROD_IOC_Linux += DPP_Test
   PROD_IOC_Linux += test_mapping
+endif
 endif
 ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
   LIBRARY_IOC_WIN32   += mcaDante

--- a/danteApp/danteSrc/Makefile
+++ b/danteApp/danteSrc/Makefile
@@ -9,7 +9,7 @@ include $(TOP)/configure/CONFIG
 DBD += mcaDanteSupport.dbd
 PROD_NAME = mcaDanteApp
 
-ifeq (linux-x86_64, $(findstring x86_64, $(T_A)))
+ifeq (x86_64, $(findstring x86_64, $(T_A)))
   USR_CXXFLAGS_Linux += -std=c++11
   LIBRARY_IOC_Linux += mcaDante
   PROD_IOC_Linux  += $(PROD_NAME)

--- a/danteApp/danteSrc/Makefile
+++ b/danteApp/danteSrc/Makefile
@@ -9,7 +9,7 @@ include $(TOP)/configure/CONFIG
 DBD += mcaDanteSupport.dbd
 PROD_NAME = mcaDanteApp
 
-ifeq (x86_64, $(findstring x86_64, $(T_A)))
+ifeq (x86_64, $(findstring x86_64, $(ARCH_CLASS)))
   USR_CXXFLAGS_Linux += -std=c++11
   LIBRARY_IOC_Linux += mcaDante
   PROD_IOC_Linux  += $(PROD_NAME)

--- a/danteApp/danteSrc/Makefile
+++ b/danteApp/danteSrc/Makefile
@@ -9,7 +9,7 @@ include $(TOP)/configure/CONFIG
 DBD += mcaDanteSupport.dbd
 PROD_NAME = mcaDanteApp
 
-ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
+ifeq (linux-x86_64, $(findstring x86_64, $(T_A)))
   USR_CXXFLAGS_Linux += -std=c++11
   LIBRARY_IOC_Linux += mcaDante
   PROD_IOC_Linux  += $(PROD_NAME)

--- a/danteApp/danteSupport/Makefile
+++ b/danteApp/danteSupport/Makefile
@@ -10,7 +10,7 @@ ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
 LIB_INSTALLS  += ../os/WIN32/x64/XGL_DPP.lib
 BIN_INSTALLS  += ../os/WIN32/x64/XGL_DPP.dll
 
-else ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
+else ifeq (x86_64, $(findstring x86_64, $(ARCH_CLASS)))
 LIB_INSTALLS  += ../os/Linux/libXGL_DPP.so.3.7.19
 LIB_INSTALLS  += ../os/Linux/libXGL_DPP.so.1
 LIB_INSTALLS  += ../os/Linux/libXGL_DPP.so

--- a/danteApp/danteSupport/Makefile
+++ b/danteApp/danteSupport/Makefile
@@ -10,10 +10,12 @@ ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
 LIB_INSTALLS  += ../os/WIN32/x64/XGL_DPP.lib
 BIN_INSTALLS  += ../os/WIN32/x64/XGL_DPP.dll
 
-else ifeq (x86_64, $(findstring x86_64, $(ARCH_CLASS)))
+else ifeq ($(OS_CLASS), Linux)
+ifeq ($(ARCH_CLASS), x86_64)
 LIB_INSTALLS  += ../os/Linux/libXGL_DPP.so.3.7.19
 LIB_INSTALLS  += ../os/Linux/libXGL_DPP.so.1
 LIB_INSTALLS  += ../os/Linux/libXGL_DPP.so
+endif
 endif
 
 include $(TOP)/configure/RULES


### PR DESCRIPTION
Due to the unfortunately varied level of updates among the computers used to run our softIOC's, our beamline controls group has set up different EPICS base architectures for each major version of RHEL that is installed on our computers. However, the naming convention that was used was of the form "rhel#-x86_64" rather than something like "linux-x86_64-rhel#"

Although the recommendation in EPICS base is to have target arches be named like the latter, it would be useful if the build system checked for being built under Linux and on an x86_64 processor explicitly, instead of matching strings in the target arch. 